### PR TITLE
Made minor improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ go.work.sum
 .env
 
 local/
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/go-playground/validator/v10 v10.26.0
+	github.com/goccy/go-yaml v1.17.1
 	github.com/urfave/cli/v2 v2.27.5
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.26.0 h1:SP05Nqhjcvz81uJaRfEV0YBSSSGMc/iMaVtFbr3Sw2k=
 github.com/go-playground/validator/v10 v10.26.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gorilla/schema v1.4.1 h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E=
 github.com/gorilla/schema v1.4.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=

--- a/internal/verapack/app.go
+++ b/internal/verapack/app.go
@@ -18,33 +18,33 @@ import (
 func NewApp() *cli.App {
 	return &cli.App{
 		Name:  "verapack",
-		Usage: "Verapack is a utility that automates and simplifies running Veracode SAST scans for multiple applications from your local machine.",
+		Usage: "Verapack is a utility that automates and simplifies running Veracode SAST scans for multiple applications from your local machine",
 		Commands: []*cli.Command{
 			{
 				Name:    "setup",
-				Usage:   "Configure config files and install the Java wrapper and Veracode CLI if they are not already installed.",
+				Usage:   "Configure config files and install the Java wrapper and Veracode CLI if they are not already installed",
 				Action:  setup,
 				Aliases: []string{"s"},
 			},
 			{
-				Name:    "go",
-				Usage:   "Package and/or Scan all applications in the config file.",
-				Action:  run,
+				Name:    "scan",
+				Usage:   "Package and/or Scan all applications in the config file",
+				Action:  scan,
 				Aliases: []string{"r"},
 			},
 			{
 				Name:    "credentials",
 				Aliases: []string{"c"},
-				Usage:   "Options for managing your credentials.",
+				Usage:   "Options for managing your credentials",
 				Subcommands: []*cli.Command{
 					{
 						Name:   "refresh",
-						Usage:  "Automatically re-generate your API credentials and update the credential files.",
+						Usage:  "Automatically re-generate your API credentials and update the credential files",
 						Action: refreshCredentials,
 					},
 					{
 						Name:   "configure",
-						Usage:  "Configure new credentials manually (Used for when existing credentials have expired or for when switching accounts).",
+						Usage:  "Configure new credentials manually (Used for when existing credentials have expired or for when switching accounts)",
 						Action: configureCredentials,
 					},
 				},
@@ -94,7 +94,7 @@ func setup(cCtx *cli.Context) error {
 	return nil
 }
 
-func run(cCtx *cli.Context) error {
+func scan(cCtx *cli.Context) error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Print(renderErrors(err))

--- a/internal/verapack/composite.go
+++ b/internal/verapack/composite.go
@@ -47,7 +47,7 @@ func packageAndUploadApplication(uploaderPath string, options Options, appId int
 		// Cleanup is only required if packager is run successfully, then it should be run
 		// at the end.
 		defer func() {
-			if options.AutoCleanup {
+			if *options.AutoCleanup {
 				os.RemoveAll(options.OutputDir)
 			}
 

--- a/internal/verapack/config.go
+++ b/internal/verapack/config.go
@@ -7,7 +7,7 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/go-playground/validator/v10"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 type SourceType string
@@ -17,27 +17,23 @@ const (
 	Directory SourceType = "directory"
 )
 
-const (
-	credentialFileLegacyFormat = "[default]\nveracode_api_key_id     = %s\nveracode_api_key_secret = %s"
-	credentialFileFormat       = "api:\n  key-id: %s\n  key-secret: %s"
-)
+var validate *validator.Validate
 
 //go:embed config.yaml
 var configFileBytes []byte
 
 type Options struct {
-
 	// Upload Options
 	// Name of the application profile.
 	AppName string `yaml:"app_name" validate:"required"`
 	// UploaderFilePath is the path to the Veracode Java wrapper jar file.
 	UploaderFilePath string `yaml:"-"`
 	// Create a application profile if the one provided in AppName does not exist.
-	CreateProfile bool `yaml:"create_profile"`
+	CreateProfile *bool `yaml:"create_profile"`
 	// FilePath is a []string of the filepaths for the application's artefacts.
 	ArtefactPaths []string `yaml:"artefact_paths" validate:"required_without=PackageSource,omitempty,dive,file|dir"`
 	// Name or version of the build that you want to scan.
-	Version string `yaml:"version"`
+	Version string `yaml:"version" validate:"required"`
 	// Number of minutes to wait for the scan to complete and pass policy.
 	// If the scan does not complete or fails policy, the build fails.
 	//
@@ -50,11 +46,11 @@ type Options struct {
 
 	// Packaging Options
 
-	Verbose       bool       `yaml:"verbose"`
-	AutoCleanup   bool       `yaml:"auto_cleanup"`
+	Verbose       *bool      `yaml:"verbose"`
+	AutoCleanup   *bool      `yaml:"auto_cleanup"`
 	OutputDir     string     `yaml:"-"`
 	PackageSource string     `yaml:"package_source" validate:"required_without=ArtefactPaths,omitempty,url|dir"`
-	Trust         bool       `yaml:"trust"`
+	Trust         *bool      `yaml:"trust"`
 	Type          SourceType `yaml:"type" validate:"oneof=directory repo"`
 
 	// Other options:
@@ -65,7 +61,18 @@ type Config struct {
 	Applications []Options `yaml:"applications" validate:"required,gt=0,dive"`
 }
 
-var validate *validator.Validate
+// NewConfig returns a new Config and sets all pointer values to avoid nil pointer errors downstream.
+func NewConfig() Config {
+	var b bool
+	return Config{
+		Default: Options{
+			CreateProfile: &b,
+			Verbose:       &b,
+			AutoCleanup:   &b,
+			Trust:         &b,
+		},
+	}
+}
 
 // ReadConfig loads the config from a file, sets all of the defaults/overrides and validates the input.
 func ReadConfig(filePath string) (Config, error) {
@@ -74,18 +81,9 @@ func ReadConfig(filePath string) (Config, error) {
 		return Config{}, err
 	}
 
-	c := Config{}
-
-	if err = yaml.Unmarshal(content, &c); err != nil {
+	c, err := SetDefaults(content)
+	if err != nil {
 		return Config{}, err
-	}
-
-	setDynamicDefaults(&c)
-
-	for i := range c.Applications {
-		if err = mergo.Merge(&c.Applications[i], c.Default); err != nil {
-			return Config{}, err
-		}
 	}
 
 	validate = validator.New()
@@ -97,9 +95,30 @@ func ReadConfig(filePath string) (Config, error) {
 	return c, nil
 }
 
+// SetDefaults merges the default values into the application configurations and sets any
+// dynamic defaults.
+func SetDefaults(configBytes []byte) (Config, error) {
+	c := NewConfig()
+	var err error
+
+	if err = yaml.Unmarshal(configBytes, &c); err != nil {
+		return Config{}, err
+	}
+
+	setDynamicDefaults(&c)
+
+	for i := range c.Applications {
+		if err = mergo.Merge(&c.Applications[i], c.Default, mergo.WithoutDereference); err != nil {
+			return Config{}, err
+		}
+	}
+
+	return c, nil
+}
+
 // setDynamicDefaults sets any default values that are based on dynamic values.
 func setDynamicDefaults(config *Config) {
 	if config.Default.Version == "" {
-		config.Default.Version = time.Now().Format("02 Jan 2006 Static")
+		config.Default.Version = time.Now().Format("02 Jan 2006 15:04PM Static")
 	}
 }

--- a/internal/verapack/config_test.go
+++ b/internal/verapack/config_test.go
@@ -1,0 +1,77 @@
+package verapack
+
+import (
+	_ "embed"
+	"testing"
+)
+
+type args struct {
+	configBytes []byte
+}
+
+type testConfig struct {
+	want           Config
+	name           string
+	args           args
+	wantErr        bool
+	validationFunc func(t *testing.T, tc testConfig, got Config)
+}
+
+func TestSetDefaults(t *testing.T) {
+	tests := []testConfig{
+		{
+			// default bool value = [true|omitted|false] + target bool value = [false], should = target bool value = false
+			// default bool value = [true|omitted|false] + target bool value = [true], should = target bool value = true
+			// default bool value = [true] + target bool value = [omitted], should = target bool value = [true]
+			name: "config bool value overrides vs. defaults bug",
+			args: args{configBytes: []byte(`
+default:
+  create_profile: true
+  auto_cleanup: false
+  trust: true
+applications:
+  - app_name: Test
+    create_profile: false
+    auto_cleanup: true`)},
+			wantErr: false,
+			validationFunc: func(t *testing.T, tc testConfig, got Config) {
+				// create_profile being used to check default true target false, expect false
+				// auto_cleanup being used to check default false target true, expect true
+				// trust being used to check default true target omitted, expect true
+				if *got.Applications[0].CreateProfile || !*got.Applications[0].AutoCleanup || !*got.Applications[0].Trust {
+					t.Errorf("SetDefaults() = create_profile=%t auto_cleanup=%t trust=%t, want create_profile=%t auto_cleanup=%t trust=%t", *got.Applications[0].CreateProfile, *got.Applications[0].AutoCleanup, *got.Applications[0].Trust, *got.Applications[0].CreateProfile, *got.Applications[0].AutoCleanup, *got.Applications[0].Trust)
+				}
+			},
+		},
+		{
+			name: "config override default non-empty value",
+			args: args{configBytes: []byte(`
+default:
+  type: directory
+applications:
+  - app_name: Test
+    type: repo`)},
+			want: Config{
+				Applications: []Options{{
+					Type: "repo",
+				}},
+			},
+			wantErr: false,
+			validationFunc: func(t *testing.T, tc testConfig, got Config) {
+				if got.Applications[0].Type != tc.want.Applications[0].Type {
+					t.Errorf("SetDefaults() = type=%s, want type=%s", got.Applications[0].Type, tc.want.Applications[0].Type)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SetDefaults(tt.args.configBytes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetDefaults() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			tt.validationFunc(t, tt, got)
+		})
+	}
+}

--- a/internal/verapack/credentials.go
+++ b/internal/verapack/credentials.go
@@ -14,6 +14,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+const (
+	credentialFileLegacyFormat = "[default]\nveracode_api_key_id     = %s\nveracode_api_key_secret = %s"
+	credentialFileFormat       = "api:\n  key-id: %s\n  key-secret: %s"
+)
+
 // setLegacyCredentialsFile creates/truncates the credential file: %home%/.veracode/credential
 func setLegacyCredentialsFile(homeDir, apiKey, apiSecret string) error {
 	file, err := os.Create(filepath.Join(homeDir, ".veracode", "credentials"))

--- a/internal/verapack/package.go
+++ b/internal/verapack/package.go
@@ -17,11 +17,11 @@ var (
 func packageOptionsToArgs(options Options) []string {
 	r := []string{"package"}
 
-	if options.Verbose {
+	if *options.Verbose {
 		r = append(r, "-v")
 	}
 
-	if options.Trust {
+	if *options.Trust {
 		r = append(r, "-a")
 	}
 
@@ -100,7 +100,7 @@ func getArtefactPath(dirPath string) ([]string, error) {
 	return r, nil
 }
 
-// TODO: baseDir is the temp dir + app folder
+// NOTE: baseDir is the temp dir + app folder
 // Creates the path and returns said path
 func createAppPackagingOutputDir(appName string) (string, error) {
 	path := filepath.Join(os.TempDir(), "verapack", appName, strconv.FormatInt(time.Now().Unix(), 10))

--- a/internal/verapack/scan.go
+++ b/internal/verapack/scan.go
@@ -14,7 +14,8 @@ func appsToRows(applications []Options) []reportcard.Row {
 			Tasks: []reportcard.Task{
 				{Status: reportcard.NotStarted},
 				{Status: reportcard.NotStarted},
-				{Status: reportcard.NotStarted, ShouldRunAnyway: true},
+				// Cleanup should show "running" even if scan fails, but not if packaging fails.
+				{Status: reportcard.NotStarted, ShouldRunAnywayFor: map[int]bool{1: true}},
 			},
 		}
 
@@ -23,7 +24,7 @@ func appsToRows(applications []Options) []reportcard.Row {
 			row.Tasks[0].Status = reportcard.Skip
 		}
 
-		if !application.AutoCleanup || application.PackageSource == "" {
+		if !*application.AutoCleanup || application.PackageSource == "" {
 			// If AutoCleanup is false, indicate that cleanup task will be skipped
 			row.Tasks[2].Status = reportcard.Skip
 		}

--- a/internal/verapack/upload.go
+++ b/internal/verapack/upload.go
@@ -25,7 +25,7 @@ func uploadOptionsToArgs(options Options) []string {
 	r = append(r,
 		"-appname", options.AppName,
 		"-version", options.Version,
-		"-createprofile", strconv.FormatBool(options.CreateProfile),
+		"-createprofile", strconv.FormatBool(*options.CreateProfile),
 	)
 
 	// Optional fields


### PR DESCRIPTION
Made help text more consistent.

Fixed bug where cleanup step on reportcard loads forever when packaging fails.

Made default scan names more specific to avoid scan name conflicts.

Renamed cli action "go" to "scan".

Organized credential variables.

Fixed bug with app specific settings not overriding default values.

Migrated to goccy/go-yaml yaml package.

Fixed bug where cleanup step on reportcard loads forever when packaging fails.

Added IDE settings folder to .gitignore